### PR TITLE
Add response time logging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-watson-developer-cloud
-pytest
-argparse
-requests
+watson-developer-cloud==0.26.1
+pytest==3.1.3
+requests==2.18.1

--- a/rnr_debug_helpers/utils/discovery_wrappers.py
+++ b/rnr_debug_helpers/utils/discovery_wrappers.py
@@ -8,9 +8,9 @@ import json
 import logging
 import sys
 import time
-from datetime import timedelta
 import urllib.parse
 from collections import defaultdict
+from datetime import timedelta
 from multiprocessing import Manager, Process, active_children
 from os import path
 from pprint import pprint
@@ -18,9 +18,11 @@ from shutil import move
 from warnings import warn
 
 import requests
+from requests.adapters import HTTPAdapter
 from watson_developer_cloud import discovery_v1
 
-from rnr_debug_helpers.utils.io_helpers import load_config, initialize_logger, smart_file_open, get_temp_file
+from rnr_debug_helpers.utils.io_helpers import load_config, initialize_logger, smart_file_open, get_temp_file, \
+    initialize_retry_settings
 from rnr_debug_helpers.utils.predictions import Prediction
 
 # only applicable if you don't use the natural_language_query parameter
@@ -66,7 +68,7 @@ def search_for_byod_environment_id(discovery):
     for environment in discovery.get_environments()['environments']:
         if environment['name'] == 'byod':
             return environment['environment_id']
-    raise RuntimeError('Need to specify an environment id, couldnt find one in the config...')
+    raise RuntimeError("Need to specify an environment id, couldn't find one in the config...")
 
 
 class DiscoveryProxy(object):
@@ -74,7 +76,6 @@ class DiscoveryProxy(object):
     My convenience wrapper for the Discovery API calls as well as helper methods to pre-process/post-process
         data going into and out of those API calls.
     """
-    _MAX_RETRIES = 3
 
     def __init__(self, config=load_config(), logger=initialize_logger(logging.INFO, 'DiscoveryProxy')):
         """
@@ -87,6 +88,11 @@ class DiscoveryProxy(object):
         self.discovery = initialize_discovery_service(config)
         self.environment_id = config.get('Discovery', 'environment_id',
                                          fallback=search_for_byod_environment_id(self.discovery))
+        self.http_connection = requests.Session()
+        self.http_connection.auth = (config.get('Discovery', 'user'), config.get('Discovery', 'password'))
+        self.http_connection.headers = {'x-global-transaction-id': 'rnr-tuning-scripts'}
+        self.http_connection.mount('https://', HTTPAdapter(max_retries=initialize_retry_settings(config)))
+        self.http_connection.mount('http://', HTTPAdapter(max_retries=initialize_retry_settings(config)))
 
     @property
     def environment_id(self):
@@ -106,12 +112,10 @@ class DiscoveryProxy(object):
 
         response = None
         try:
-            response = requests.get("{}/v1/environments/{}/collections/{}/query".format(self.discovery.url,
-                                                                                        self.environment_id,
-                                                                                        collection_id),
-                                    params=urllib.parse.urlencode(query_parameters),
-                                    auth=(
-                                        self.config.get('Discovery', 'user'), self.config.get('Discovery', 'password')))
+            response = self.http_connection.get("{}/v1/environments/{}/collections/{}/query".format(self.discovery.url,
+                                                                                                    self.environment_id,
+                                                                                                    collection_id),
+                                                params=urllib.parse.urlencode(query_parameters))
             response.raise_for_status()
             predictions = self._parse_response_content_for_predictions(question_number, response)
         except Exception as ex:
@@ -327,16 +331,13 @@ class DiscoveryProxy(object):
         self.logger.info('Uploaded %d queries worth of training data' % num_queries)
 
     def _upload_training_example(self, training_example_for_discovery, collection_id):
-        response = requests.post(
+        response = self.http_connection.post(
             "{}/v1/environments/{}/collections/{}/training_data".format(self.discovery.url,
                                                                         self.environment_id,
                                                                         collection_id),
             data=json.dumps(training_example_for_discovery),
-            auth=(
-                self.config.get('Discovery', 'user'),
-                self.config.get('Discovery', 'password')),
             params={'version': self.discovery.version},
-            headers={'x-global-transaction-id': 'Rishavs app', 'Content-type': 'application/json'})
+            headers={'Content-type': 'application/json'})
         if response.status_code == 409:
             self.logger.warn('Encountered this query text a second time, so just adding the examples: %s' %
                              training_example_for_discovery['natural_language_query'])
@@ -345,17 +346,14 @@ class DiscoveryProxy(object):
 
             for example in training_example_for_discovery['examples']:
                 if example['document_id'] not in previously_labelled_doc_ids:
-                    response = requests.post(
+                    response = self.http_connection.post(
                         "{}/v1/environments/{}/collections/{}/training_data/{}/examples".format(self.discovery.url,
                                                                                                 self.environment_id,
                                                                                                 collection_id,
                                                                                                 query_id),
                         data=json.dumps(example),
-                        auth=(
-                            self.config.get('Discovery', 'user'),
-                            self.config.get('Discovery', 'password')),
                         params={'version': self.discovery.version},
-                        headers={'x-global-transaction-id': 'Rishavs app', 'Content-type': 'application/json'})
+                        headers={'Content-type': 'application/json'})
                     if response.status_code != 200 or self.logger.isEnabledFor(logging.DEBUG):
                         pprint(vars(response))
                     response.raise_for_status()
@@ -380,15 +378,12 @@ class DiscoveryProxy(object):
     def _find_query_id_for_previously_uploaded_example(self, collection_id, training_example_for_discovery):
         self.logger.warn('Found more than one labelled query with the same text, consolidating into the same'
                          ' training example for Discovery')
-        response = requests.get(
+        response = self.http_connection.get(
             "{}/v1/environments/{}/collections/{}/training_data".format(self.discovery.url,
                                                                         self.environment_id,
                                                                         collection_id),
-            auth=(
-                self.config.get('Discovery', 'user'),
-                self.config.get('Discovery', 'password')),
             params={'version': self.discovery.version},
-            headers={'x-global-transaction-id': 'Rishavs app', 'Content-type': 'application/json'})
+            headers={'Content-type': 'application/json'})
         if response.status_code != 200 or self.logger.isEnabledFor(logging.DEBUG):
             pprint(vars(response))
         response.raise_for_status()

--- a/rnr_debug_helpers/utils/discovery_wrappers.py
+++ b/rnr_debug_helpers/utils/discovery_wrappers.py
@@ -145,7 +145,6 @@ class DiscoveryProxy(object):
 
         temp_file = get_temp_file(prediction_file_location)
         stats = defaultdict(float)
-        stats['response_time'] = timedelta(seconds=0)
         with smart_file_open(temp_file, 'w') as prediction_outfile:
             writer = csv.writer(prediction_outfile, delimiter=' ')
             for query in test_questions:
@@ -155,7 +154,7 @@ class DiscoveryProxy(object):
                                                                            query_text=query.get_qid(),
                                                                            collection_id=collection_id,
                                                                            num_results_to_return=num_rows)
-                stats['response_time'] += response_time
+                stats['response_time_in_seconds'] += response_time.total_seconds()
                 if predictions:
                     stats['num_results_returned'] += len(predictions)
                     self._write_results_to_file(predictions, writer)
@@ -166,7 +165,7 @@ class DiscoveryProxy(object):
 
             if stats['num_questions'] < 1:
                 raise ValueError("No test instances found in the file")
-            stats['avg_response_time'] = stats['response_time'] / stats['num_questions']
+            stats['avg_response_time_in_seconds'] = stats['response_time_in_seconds'] / stats['num_questions']
 
         move(temp_file, prediction_file_location)
 

--- a/rnr_debug_helpers/utils/io_helpers.py
+++ b/rnr_debug_helpers/utils/io_helpers.py
@@ -13,6 +13,7 @@ from collections import OrderedDict
 from collections import deque
 from configparser import ConfigParser
 from warnings import warn
+from urllib3.util.retry import Retry
 
 from pkg_resources import resource_filename
 
@@ -35,6 +36,16 @@ def initialize_logger(log_level, name):
         logger.addHandler(ch)
 
     return logger
+
+
+def initialize_retry_settings(config):
+    return Retry(connect=config.getint('HttpRetrySettings', 'on_connection_error', fallback=5),
+                 read=config.getint('HttpRetrySettings', 'on_read_error', fallback=2),
+                 redirect=config.getint('HttpRetrySettings', 'on_redirect_error', fallback=2),
+                 status=config.getint('HttpRetrySettings', 'on_internal_server_error', fallback=2),
+                 status_forcelist=[500],
+                 backoff_factor=config.getfloat('HttpRetrySettings',
+                                                'back_off_factor_between_retries', fallback=0.2))
 
 
 def load_config(config_file_path=resource_filename('config', 'config.ini'), encoding=DEFAULT_ENCODING):

--- a/rnr_debug_helpers/utils/rnr_wrappers.py
+++ b/rnr_debug_helpers/utils/rnr_wrappers.py
@@ -10,6 +10,7 @@ import sys
 import tempfile
 import urllib.parse
 from collections import defaultdict
+from datetime import timedelta
 from os import path
 from pprint import pprint
 from shutil import move
@@ -135,7 +136,7 @@ class RetrieveAndRankProxy(AbstractBluemixProxy):
             if response is not None:
                 pprint(vars(response))
             raise
-        return predictions
+        return predictions, response.elapsed
 
     def generate_fcselect_prediction_scores(self, test_questions, prediction_file_location, collection_id, num_rows=10,
                                             ranker_id=None):
@@ -161,15 +162,18 @@ class RetrieveAndRankProxy(AbstractBluemixProxy):
 
         temp_file = get_temp_file(prediction_file_location)
         stats = defaultdict(float)
+        stats['response_time'] = timedelta(seconds=0)
         with smart_file_open(temp_file, 'w') as prediction_outfile:
             writer = csv.writer(prediction_outfile, delimiter=' ')
             for query in test_questions:
                 stats['num_questions'] += 1
                 self.logger.debug("Generate predictions for query <<%s>>" % query.get_qid())
-                predictions = self._get_runtime_predictions(stats['num_questions'],
-                                                            query_text=query.get_qid(),
-                                                            collection_id=collection_id,
-                                                            num_results_to_return=num_rows, ranker_id=ranker_id)
+                predictions, response_time = self._get_runtime_predictions(stats['num_questions'],
+                                                                           query_text=query.get_qid(),
+                                                                           collection_id=collection_id,
+                                                                           num_results_to_return=num_rows,
+                                                                           ranker_id=ranker_id)
+                stats['response_time'] += response_time
                 if predictions:
                     stats['num_results_returned'] += len(predictions)
                     self._write_results_to_file(predictions, writer)
@@ -180,6 +184,7 @@ class RetrieveAndRankProxy(AbstractBluemixProxy):
 
             if stats['num_questions'] < 1:
                 raise ValueError("No test instances found in the file")
+            stats['avg_response_time'] = stats['response_time'] / stats['num_questions']
         move(temp_file, prediction_file_location)
 
         self.logger.info("Completed getting runtime predictions for %d questions" % stats['num_questions'])

--- a/rnr_debug_helpers/utils/rnr_wrappers.py
+++ b/rnr_debug_helpers/utils/rnr_wrappers.py
@@ -10,7 +10,6 @@ import sys
 import tempfile
 import urllib.parse
 from collections import defaultdict
-from datetime import timedelta
 from os import path
 from pprint import pprint
 from shutil import move
@@ -162,7 +161,6 @@ class RetrieveAndRankProxy(AbstractBluemixProxy):
 
         temp_file = get_temp_file(prediction_file_location)
         stats = defaultdict(float)
-        stats['response_time'] = timedelta(seconds=0)
         with smart_file_open(temp_file, 'w') as prediction_outfile:
             writer = csv.writer(prediction_outfile, delimiter=' ')
             for query in test_questions:
@@ -173,7 +171,7 @@ class RetrieveAndRankProxy(AbstractBluemixProxy):
                                                                            collection_id=collection_id,
                                                                            num_results_to_return=num_rows,
                                                                            ranker_id=ranker_id)
-                stats['response_time'] += response_time
+                stats['response_time_in_seconds'] += response_time.total_seconds()
                 if predictions:
                     stats['num_results_returned'] += len(predictions)
                     self._write_results_to_file(predictions, writer)
@@ -184,7 +182,7 @@ class RetrieveAndRankProxy(AbstractBluemixProxy):
 
             if stats['num_questions'] < 1:
                 raise ValueError("No test instances found in the file")
-            stats['avg_response_time'] = stats['response_time'] / stats['num_questions']
+            stats['avg_response_time_in_seconds'] = stats['response_time_in_seconds'] / stats['num_questions']
         move(temp_file, prediction_file_location)
 
         self.logger.info("Completed getting runtime predictions for %d questions" % stats['num_questions'])


### PR DESCRIPTION
Sometimes it's helpful to keep track of average response times from Discovery/Retrieve-and-Rank when making predictions as you play with different settings (like how many documents to retrieve).  To facilitate the same, I now keep track of the [elapsed time](http://docs.python-requests.org/en/master/api/#requests.Response.elapsed) when making prediction queries.  In addition, I:

- fix the versions being used (since `requests.elapsed` is not available in older versions of the requests library)

- switched the discovery wrapper's prediction calls to using requests.Sessions (since the docs claim this is faster on account of maintaining the same TCP connection for repeated requests to the same URL).  A similar switch is feasible for the retrieve-and-rank wrappers and is still pending.

- added the ability to specify granular retry logic since Discovery misbehaves sometimes when under heavy concurrent loads...so it's nice to be able to automatically retry the request in case of a variety of failure conditions.  These can be controlled via the config.